### PR TITLE
chore(k8s): deploy real estate microservices on Linode

### DIFF
--- a/microservices/Values/inventory-service-values.yaml
+++ b/microservices/Values/inventory-service-values.yaml
@@ -1,0 +1,10 @@
+appName: inventory
+appImage: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/inventory-service
+appVersion: "1.0"
+appReplicas: 1
+containerPort: 5005
+containerEnvVars: 
+- name: PORT
+  value: "5005"
+
+servicePort: 5005

--- a/microservices/Values/listing-service-values.yaml
+++ b/microservices/Values/listing-service-values.yaml
@@ -1,0 +1,14 @@
+appName: listings
+appImage: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/listing-service
+appVersion: "1.0"
+appReplicas: 1
+containerPort: 5001
+containerEnvVars: 
+- name: PORT
+  value: "5001"
+- name: PROPERTY_SERVICE_URL
+  value: "http://property:5004"
+- name: PRICE_SERVICE_URL
+  value: "http://price:5006"
+
+servicePort: 5001

--- a/microservices/Values/platform-service-values.yaml
+++ b/microservices/Values/platform-service-values.yaml
@@ -1,0 +1,11 @@
+appName: platform
+appImage: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/platform-service
+appVersion: "1.0"
+appReplicas: 1
+containerPort: 5010
+containerEnvVars: 
+- name: PORT
+  value: "5010"
+
+serviceType: LoadBalancer
+servicePort: 5010

--- a/microservices/Values/price-service-values.yaml
+++ b/microservices/Values/price-service-values.yaml
@@ -1,0 +1,10 @@
+appName: price
+appImage: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/price-service
+appVersion: "1.0"
+appReplicas: 1
+containerPort: 5006
+containerEnvVars: 
+- name: PORT
+  value: "5006"
+
+servicePort: 5006

--- a/microservices/Values/property-service-values.yaml
+++ b/microservices/Values/property-service-values.yaml
@@ -1,0 +1,14 @@
+appName: property
+appImage: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/property-service
+appVersion: "1.0"
+appReplicas: 1
+containerPort: 5004
+containerEnvVars: 
+- name: PORT
+  value: "5004"
+- name: INVENTORY_SERVICE_URL
+  value: "http://inventory:5005"
+- name: PRICE_SERVICE_URL
+  value: "http://price:5006"
+
+servicePort: 5004

--- a/microservices/Values/tenant-service-values.yaml
+++ b/microservices/Values/tenant-service-values.yaml
@@ -1,0 +1,10 @@
+appName: tenant
+appImage: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/tenant-service
+appVersion: "1.0"
+appReplicas: 1
+containerPort: 5003
+containerEnvVars: 
+- name: PORT
+  value: "5003"
+
+servicePort: 5003

--- a/microservices/Values/users-service-values.yaml
+++ b/microservices/Values/users-service-values.yaml
@@ -1,10 +1,10 @@
 appName: users
 appImage: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/user-services
-appVersion: 1.0
-appReplicas: 2
+appVersion: "1.0"
+appReplicas: 1
 containerPort: 5002
 containerEnvVars: 
-- name: UPORT
+- name: PORT
   value: "5002"
 
 servicePort: 5002

--- a/microservices/config.yaml
+++ b/microservices/config.yaml
@@ -1,0 +1,347 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: users
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: users
+  template:
+    metadata:
+      labels:
+        app: users
+    spec:
+      imagePullSecrets:
+      - name: ecr-secret
+      containers:
+      - name: service
+        image: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/user-services:1.0
+        ports:
+        - containerPort: 5002
+        env:
+        - name: PORT
+          value: "5002"
+        envFrom:
+        - secretRef:
+            name: app-secrets
+        resources:
+          requests: 
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: users
+spec:
+  type: ClusterIP
+  selector:
+    app: users
+  ports:
+  - protocol: TCP
+    port: 5002
+    targetPort: 5002
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: listings
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: listings
+  template:
+    metadata:
+      labels:
+        app: listings
+    spec:
+      imagePullSecrets:
+      - name: ecr-secret
+      containers:
+      - name: service
+        image: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/listing-service:1.0
+        ports:
+        - containerPort: 5001
+        env:
+        - name: PORT
+          value: "5001"
+        - name: PROPERTY_SERVICE_URL
+          value: "http://property:5004"
+        - name: PRICE_SERVICE_URL
+          value: "http://price:5006"
+        envFrom:
+        - secretRef:
+            name: app-secrets
+        resources:
+          requests: 
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: listings
+spec:
+  type: ClusterIP
+  selector:
+    app: listings
+  ports:
+  - protocol: TCP
+    port: 5001
+    targetPort: 5001
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: property
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: property
+  template:
+    metadata:
+      labels:
+        app: property
+    spec:
+      imagePullSecrets:
+      - name: ecr-secret
+      containers:
+      - name: service
+        image: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/property-service:1.0
+        ports:
+        - containerPort: 5004
+        env:
+        - name: PORT
+          value: "5004"
+        - name: INVENTORY_SERVICE_URL
+          value: "http://inventory:5005"
+        - name: PRICE_SERVICE_URL
+          value: "http://price:5006"
+        envFrom:
+        - secretRef:
+            name: app-secrets
+        resources:
+          requests: 
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: property
+spec:
+  type: ClusterIP
+  selector:
+    app: property
+  ports:
+  - protocol: TCP
+    port: 5004
+    targetPort: 5004
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tenant
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tenant
+  template:
+    metadata:
+      labels:
+        app: tenant
+    spec:
+      imagePullSecrets:
+      - name: ecr-secret
+      containers:
+      - name: service
+        image: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/tenant-service:1.0
+        ports:
+        - containerPort: 5003
+        env:
+        - name: PORT
+          value: "5003"
+        envFrom:
+        - secretRef:
+            name: app-secrets
+        resources:
+          requests: 
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tenant
+spec:
+  type: ClusterIP
+  selector:
+    app: tenant
+  ports:
+  - protocol: TCP
+    port: 5003
+    targetPort: 5003
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inventory
+  template:
+    metadata:
+      labels:
+        app: inventory
+    spec:
+      imagePullSecrets:
+      - name: ecr-secret
+      containers:
+      - name: service
+        image: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/inventory-service:1.0
+        ports:
+        - containerPort: 5005
+        env:
+        - name: PORT
+          value: "5005"
+        envFrom:
+        - secretRef:
+            name: app-secrets
+        resources:
+          requests: 
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory
+spec:
+  type: ClusterIP
+  selector:
+    app: inventory
+  ports:
+  - protocol: TCP
+    port: 5005
+    targetPort: 5005
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: price
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: price
+  template:
+    metadata:
+      labels:
+        app: price
+    spec:
+      imagePullSecrets:
+      - name: ecr-secret
+      containers:
+      - name: service
+        image: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/price-service:1.0
+        ports:
+        - containerPort: 5006
+        env:
+        - name: "PORT"
+          value: "5006"
+        envFrom:
+        - secretRef:
+            name: app-secrets
+        resources:
+          requests: 
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: price
+spec:
+  type: ClusterIP
+  selector:
+    app: price
+  ports:
+  - protocol: TCP
+    port: 5006
+    targetPort: 5006
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: platform
+  template:
+    metadata:
+      labels:
+        app: platform
+    spec:
+      imagePullSecrets:
+      - name: ecr-secret
+      containers:
+      - name: service
+        image: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/platform-service:1.0
+        ports:
+        - containerPort: 5010
+        env:
+        - name: PORT
+          value: "5010"
+        resources:
+          requests: 
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: platform
+spec:
+  type: LoadBalancer
+  selector:
+    app: platform
+  ports:
+  - protocol: TCP
+    port: 5010
+    targetPort: 5010
+    

--- a/microservices/helm-postgre.yaml
+++ b/microservices/helm-postgre.yaml
@@ -1,0 +1,20 @@
+architecture: replication
+
+auth:
+  postgresPassword: "admin-postgres-password"
+  username: "realestate"
+  password: "realestatepass"
+  database: "realestate"
+
+primary:
+  persistence:
+    enabled: true
+    storageClass: "linode-block-storage"
+    size: 8Gi
+
+readReplicas:
+  replicaCount: 2
+  persistence:
+    enabled: true
+    storageClass: "linode-block-storage"
+    size: 8Gi

--- a/microservices/helmfile.yaml
+++ b/microservices/helmfile.yaml
@@ -1,0 +1,37 @@
+releases:
+  - name: inventoryservice
+    chart: microservice
+    values: 
+      - Values/inventory-service-values.yaml
+
+  - name: listingservice
+    chart: microservice
+    values: 
+      - Values/listing-service-values.yaml
+
+  - name: platformservice
+    chart: microservice
+    values: 
+      - Values/platform-service-values.yaml
+
+  - name: priceservice
+    chart: microservice
+    values: 
+      - Values/price-service-values.yaml
+
+  - name: propertyservice
+    chart: microservice
+    values: 
+      - Values/property-service-values.yaml
+
+  - name: tenantservice
+    chart: microservice
+    values: 
+      - Values/tenant-service-values.yaml
+
+  - name: userservice
+    chart: microservice
+    values: 
+      - Values/users-service-values.yaml
+
+  

--- a/microservices/microservice/.helmignore
+++ b/microservices/microservice/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/microservices/microservice/Chart.yaml
+++ b/microservices/microservice/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: microservice
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/microservices/microservice/templates/deployment.yaml
+++ b/microservices/microservice/templates/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         app: {{ .Values.appName }}
     spec:
+      imagePullSecrets:
+      - name: {{ .Values.imageSecrets }}
       containers:
       - name: {{ .Values.appName }}
         image: "{{ .Values.appImage }}:{{ .Values.appVersion }}"
@@ -22,4 +24,14 @@ spec:
         - name: {{ .name }}
           value: {{ .value | quote }}
         {{- end}}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.secretName }}
+        resources:
+          requests: 
+            cpu: {{ .Values.cpuRequest }}
+            memory: {{ .Values.memoryRequest }}
+          limits:
+            cpu: {{ .Values.cpuLimits }}
+            memory: {{ .Values.memoryLimits}}
        

--- a/microservices/microservice/templates/deployment.yaml
+++ b/microservices/microservice/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.appName }}
+spec:
+  replicas: {{ .Values.appReplicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.appName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.appName }}
+    spec:
+      containers:
+      - name: {{ .Values.appName }}
+        image: "{{ .Values.appImage }}:{{ .Values.appVersion }}"
+        ports:
+        - containerPort: {{ .Values.containerPort}}
+        env:
+        {{- range .Values.containerEnvVars}}
+        - name: {{ .name }}
+          value: {{ .value | quote }}
+        {{- end}}
+       

--- a/microservices/microservice/templates/service.yaml
+++ b/microservices/microservice/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.appName }}
+spec:
+  type: {{ .Values.serviceType }}
+  selector:
+    app: {{ .Values.appName }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.servicePort }}
+    targetPort: {{ .Values.containerPort }}

--- a/microservices/microservice/values.yaml
+++ b/microservices/microservice/values.yaml
@@ -1,0 +1,161 @@
+# Default values for microservice.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: nginx
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+
+# -- Expose the service via gateway-api HTTPRoute
+# Requires Gateway API resources and suitable controller installed within the cluster
+# (see: https://gateway-api.sigs.k8s.io/guides/)
+httpRoute:
+  # HTTPRoute enabled.
+  enabled: false
+  # HTTPRoute annotations.
+  annotations: {}
+  # Which Gateways this Route is attached to.
+  parentRefs:
+  - name: gateway
+    sectionName: http
+    # namespace: default
+  # Hostnames matching HTTP header.
+  hostnames:
+  - chart-example.local
+  # List of rules and filters applied.
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /headers
+  #   filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       set:
+  #       - name: My-Overwrite-Header
+  #         value: this-is-the-only-value
+  #       remove:
+  #       - User-Agent
+  # - matches:
+  #   - path:
+  #       type: PathPrefix
+  #       value: /echo
+  #     headers:
+  #     - name: version
+  #       value: v2
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+  # - name: foo
+  #   secret:
+  #     secretName: mysecret
+  #     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+  # - name: foo
+  #   mountPath: "/etc/foo"
+  #   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/microservices/microservice/values.yaml
+++ b/microservices/microservice/values.yaml
@@ -1,161 +1,20 @@
-# Default values for microservice.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+appName: servicename
+appImage: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/servicename
+appVersion: "1.0"
+appReplicas: 1
+secretName: app-secrets
+imageSecrets: ecr-secret
+containerPort: 5002
+containerEnvVars:
+- name: ENV_VAR_ONE
+  value: "valueone"
+- name: ENV_VAR_TWO
+  value: "valuetwo"
 
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
-replicaCount: 1
+cpuRequest: 50m
+cpuLimits: 200m
+memoryRequest: 64Mi
+memoryLimits: 128Mi
 
-# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
-image:
-  repository: nginx
-  # This sets the pull policy for images.
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
-
-# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-imagePullSecrets: []
-# This is to override the chart name.
-nameOverride: ""
-fullnameOverride: ""
-
-# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
-serviceAccount:
-  # Specifies whether a service account should be created.
-  create: true
-  # Automatically mount a ServiceAccount's API credentials?
-  automount: true
-  # Annotations to add to the service account.
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template.
-  name: ""
-
-# This is for setting Kubernetes Annotations to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-podAnnotations: {}
-# This is for setting Kubernetes Labels to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-podLabels: {}
-
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-
-# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
-service:
-  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-  type: ClusterIP
-  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 80
-
-# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
-
-# -- Expose the service via gateway-api HTTPRoute
-# Requires Gateway API resources and suitable controller installed within the cluster
-# (see: https://gateway-api.sigs.k8s.io/guides/)
-httpRoute:
-  # HTTPRoute enabled.
-  enabled: false
-  # HTTPRoute annotations.
-  annotations: {}
-  # Which Gateways this Route is attached to.
-  parentRefs:
-  - name: gateway
-    sectionName: http
-    # namespace: default
-  # Hostnames matching HTTP header.
-  hostnames:
-  - chart-example.local
-  # List of rules and filters applied.
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /headers
-  #   filters:
-  #   - type: RequestHeaderModifier
-  #     requestHeaderModifier:
-  #       set:
-  #       - name: My-Overwrite-Header
-  #         value: this-is-the-only-value
-  #       remove:
-  #       - User-Agent
-  # - matches:
-  #   - path:
-  #       type: PathPrefix
-  #       value: /echo
-  #     headers:
-  #     - name: version
-  #       value: v2
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  httpGet:
-    path: /
-    port: http
-readinessProbe:
-  httpGet:
-    path: /
-    port: http
-
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
-# Additional volumes on the output Deployment definition.
-volumes: []
-  # - name: foo
-  #   secret:
-  #     secretName: mysecret
-  #     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-  # - name: foo
-  #   mountPath: "/etc/foo"
-  #   readOnly: true
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
+servicePort: 5002
+serviceType: ClusterIP

--- a/microservices/users-service-values.yaml
+++ b/microservices/users-service-values.yaml
@@ -1,0 +1,10 @@
+appName: users
+appImage: 762760349103.dkr.ecr.eu-north-1.amazonaws.com/microservices/user-services
+appVersion: 1.0
+appReplicas: 2
+containerPort: 5002
+containerEnvVars: 
+- name: UPORT
+  value: "5002"
+
+servicePort: 5002


### PR DESCRIPTION
Deploy real estate microservices on Linode. Add Kubernetes deployments and services for users, listings, tenants, property, inventory, price, and platform. Configure ECR image pull secrets, app secrets, service discovery URLs, resource limits, and PostgreSQL primary database connection.